### PR TITLE
Add Dockerfile

### DIFF
--- a/Docker.md
+++ b/Docker.md
@@ -1,0 +1,59 @@
+# Docker Usage Guide
+
+## Building the Docker Image
+
+```sh
+sudo docker build -t dnsprober .
+```
+
+## Running dnsprober in Docker
+
+```sh
+sudo docker run --rm dnsprober --help
+```
+
+## Using a File as Input in Docker
+
+When using files as input, you need to mount the file into the container using `-v`.
+
+```sh
+sudo docker run --rm -v /path/to/input/input.txt:/input.txt dnsprober -l /input.txt
+```
+
+## Example Commands
+### Using Subdominator Output as Input
+```sh
+subdominator -d hackerone.com -s | sudo docker run --rm -i dnsprober --response -s
+```
+```sh
+subdominator -d hackerone.com -s | sudo docker run --rm -i dnsprober --dns-response -s
+```
+```sh
+subdominator -d hackerone.com -s | sudo docker run --rm -i dnsprober --response -s --cname
+```
+
+### Wildcard Filtering
+```sh
+sudo docker run --rm dnsprober -d freshworks.com -w wordlist.txt --wildcard-domain wildcard-domain.freshworks.com
+```
+
+### PTR Record Lookup for an IP Range
+```sh
+prips 157.240.19.0/24 | sudo docker run --rm -i dnsprober --ptr --response
+```
+
+### Running with Custom Resolvers
+```sh
+sudo docker run --rm -v /path/to/resolvers.txt:/resolvers.txt dnsprober -d example.com -r /resolvers.txt
+```
+
+### Saving Output to a File
+```sh
+sudo docker run --rm -v $(pwd):/output dnsprober -d example.com -o /output/results.txt
+```
+
+## Notes
+- Use `-i` when piping data into `docker run`.
+- Mount files using `-v` if they are needed inside the container.
+- The `--rm` flag ensures the container is removed after execution.
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# Base - Build Stage
+FROM golang:1.24-alpine AS builder
+
+RUN apk add --no-cache build-base
+WORKDIR /app
+COPY . /app
+RUN go mod download
+RUN go build -o dnsprober ./dnsprober
+
+# Release Stage
+FROM alpine:3.18.2
+RUN apk -U upgrade --no-cache \
+    && apk add --no-cache bind-tools ca-certificates
+
+COPY --from=builder /app/dnsprober /usr/local/bin/
+
+ENTRYPOINT ["dnsprober"]


### PR DESCRIPTION
- Added a `Dockerfile` to run `dnsprober` in a container.  
- Allows using input files by mounting them.  

### **Usage**  
```bash
docker build -t dnsprober .
docker run --rm -v "/path/to/subs.txt:/app/subs.txt" dnsprober -l /app/subs.txt
```  